### PR TITLE
Engine fix

### DIFF
--- a/aidb/engine/approx_aggregate_engine.py
+++ b/aidb/engine/approx_aggregate_engine.py
@@ -5,7 +5,7 @@ import sqlglot.expressions as exp
 import statsmodels.stats.proportion
 from typing import List
 
-from aidb.engine.full_scan_engine import FullScanEngine
+from aidb.engine.base_engine import BaseEngine
 from aidb.estimator.estimator import (Estimator, WeightedMeanSetEstimator)
 from aidb.samplers.sampler import SampledBlob
 from aidb.query.query import Query
@@ -13,7 +13,7 @@ from aidb.query.query import Query
 _NUM_PILOT_SAMPLES = 1000
 
 
-class ApproximateAggregateEngine(FullScanEngine):
+class ApproximateAggregateEngine(BaseEngine):
   async def execute_aggregate_query(self, query: Query):
     '''
     Execute aggregation query using approximate processing
@@ -112,7 +112,7 @@ class ApproximateAggregateEngine(FullScanEngine):
     '''
     Executed inference services on sampled data
     '''
-    bound_service_list = self._get_required_bound_services_order(query)
+    bound_service_list = query.inference_engines_required_for_query
     inference_services_executed = set()
     for bound_service in bound_service_list:
       inp_query_str = self.get_input_query_for_inference_service_filter_service(bound_service, query,

--- a/aidb/engine/full_scan_engine.py
+++ b/aidb/engine/full_scan_engine.py
@@ -7,21 +7,12 @@ from aidb.inference.bound_inference_service import BoundInferenceService
 from aidb.query.query import Query
 
 class FullScanEngine(BaseEngine):
-  def _get_required_bound_services_order(self, query: Query) -> List[BoundInferenceService]:
-    bound_service_list_ordered = [
-        bound_service
-        for bound_service in self._config.inference_topological_order
-        if bound_service in query.inference_engines_required_for_query
-    ]
-    return bound_service_list_ordered
-
-
   async def execute_full_scan(self, query: Query, **kwargs):
     '''
     Executes a query by doing a full scan and returns the results.
     '''
     # The query is irrelevant since we do a full scan anyway
-    bound_service_list = self._get_required_bound_services_order(query)
+    bound_service_list = query.inference_engines_required_for_query
     inference_services_executed = set()
     for bound_service in bound_service_list:
       inp_query_str = self.get_input_query_for_inference_service_filter_service(bound_service,

--- a/aidb/engine/limit_engine.py
+++ b/aidb/engine/limit_engine.py
@@ -41,7 +41,7 @@ class LimitEngine(TastiEngine):
     desired_cardinality = int(query.get_limit_cardinality())
 
     # TODO: rewrite query, use full scan to execute query
-    bound_service_list = self._get_required_bound_services_order(query)
+    bound_service_list = query.inference_engines_required_for_query
     for index, _ in sorted_list:
       for bound_service in bound_service_list:
         inp_query_str = self.get_input_query_for_inference_service_filtered_index(bound_service,

--- a/aidb/engine/tasti_engine.py
+++ b/aidb/engine/tasti_engine.py
@@ -37,15 +37,8 @@ class TastiEngine(FullScanEngine):
     2. infer all bound services for all cluster representatives blobs
     3. generate proxy score per predicate for all blobs based on topk rep ids and dists
     '''
-    bound_service_list = self._get_required_bound_services_order(query)
-
-    blob_tables = set()
-    for bound_service in bound_service_list:
-      for input_col in bound_service.binding.input_columns:
-        input_table = input_col.split('.')[0]
-        if input_table in self._config.blob_tables:
-          blob_tables.add(input_table)
-    blob_tables = list(blob_tables)
+    bound_service_list = query.inference_engines_required_for_query
+    blob_tables = query.blob_tables_required_for_query
 
     self.rep_table_name, self.topk_table_name = table_name_for_rep_and_topk(blob_tables)
     if self.rep_table_name not in self._config.tables or self.topk_table_name not in self._config.tables:

--- a/aidb/query/query.py
+++ b/aidb/query/query.py
@@ -375,7 +375,14 @@ class Query(object):
             if inference_col not in visited:
               stack.append(inference_col)
               visited.add(inference_col)
-    return list(inference_engines_required)
+
+    inference_engines_ordered = [
+      inference_engine
+      for inference_engine in self.config.inference_topological_order
+      if inference_engine in inference_engines_required
+    ]
+
+    return inference_engines_ordered
 
 
   @cached_property


### PR DESCRIPTION
This PR move the ranking inference engine function to the query class, so the returned inference_engines_required_for_query is already ordered.