### PR TITLE
refactor blob mapping table and parameter vector ids

### DIFF
--- a/aidb/utils/constants.py
+++ b/aidb/utils/constants.py
@@ -6,6 +6,7 @@ CACHE_PREFIX = '__cache'
 CONFIG_PREFIX = '__config'
 REP_PREFIX = '__rep'
 TOPK_PREFIX = '__topk'
+BLOB_MAPPING_PREFIX = '__blob_mapping'
 '''
 The schema of the blob metadata table is as follows:
   table_name: str
@@ -25,7 +26,7 @@ def cache_table_name_from_inputs(service_name: str, columns: List[str]):
   return f"{CACHE_PREFIX}__{service_name}__{column_input_hash}"
 
 
-def table_name_for_rep_and_topk(blob_tables: List[str]):
+def table_name_for_rep_and_topk_and_blob_mapping(blob_tables: List[str]):
   blob_tables.sort()
   blob_table_postfix = ''
   for idx, blob_table in enumerate(blob_tables):
@@ -34,4 +35,5 @@ def table_name_for_rep_and_topk(blob_tables: List[str]):
   # limit to 10 characters to avoid long names in the table names
   hash_length = 10
   table_input_hash = hashlib.sha1(blob_table_postfix.encode()).hexdigest()[:hash_length]
-  return f'{REP_PREFIX}__{table_input_hash}', f'{TOPK_PREFIX}__{table_input_hash}'
+  return f'{REP_PREFIX}__{table_input_hash}', f'{TOPK_PREFIX}__{table_input_hash}', \
+            f'{BLOB_MAPPING_PREFIX}__{table_input_hash}'

--- a/aidb/vector_database/tasti.py
+++ b/aidb/vector_database/tasti.py
@@ -21,9 +21,21 @@ def get_and_update_dists(x: np.ndarray, embeddings: np.ndarray, min_dists: np.nd
 class Tasti(TastiConfig):
   def __post_init__(self):
     self.rep_index_name = f'{self.index_name}__representatives'
+    self.vector_ids = None
+    self.reps = None
     self.rand = np.random.RandomState(self.seed)
-    self.embeddings = self.vector_database.get_embeddings_by_id(self.index_name,
-                                                                self.vector_ids.values.reshape(1, -1)[0])
+
+
+  def set_vector_ids(self, vector_ids: pd.DataFrame):
+    self.vector_ids = vector_ids
+    self.embeddings = self.vector_database.get_embeddings_by_id(
+      self.index_name,
+      self.vector_ids.values.reshape(1, -1)[0]
+    )
+
+
+  def set_existing_reps(self, reps: np.ndarray):
+    self.reps = reps
 
 
   # # TODO: Add memory efficient FPF Random Bucketter
@@ -35,6 +47,9 @@ class Tasti(TastiConfig):
       buckets = nb_buckets
     else:
       buckets = self.nb_buckets
+
+    if self.vector_ids is None:
+      raise Exception('Vector_ids is None, please set it first.')
 
     reps = np.full(buckets, -1)
     min_dists = np.full(len(self.embeddings), np.Inf, dtype=np.float32)
@@ -65,7 +80,7 @@ class Tasti(TastiConfig):
     if self.reps is None:
       self._FPF()
     rep_id = self.vector_ids.iloc[self.reps]
-    rep_id.set_index('id', inplace=True, drop=True)
+    rep_id.set_index('vector_id', inplace=True, drop=True)
     return rep_id
 
 

--- a/aidb/vector_database/vector_database_config.py
+++ b/aidb/vector_database/vector_database_config.py
@@ -18,12 +18,11 @@ class TastiConfig:
   :param reps: representative ids
   '''
   index_name: str
-  vector_ids: pd.DataFrame
   vector_database: VectorDatabase
-  nb_buckets: int
+  nb_buckets: int = 1000
   percent_fpf: float = 0.75
   seed: int = 1234
-  reps: Optional[np.ndarray] = field(default=None)
+
 
   # Initialize supplementary parameters in Tasti; without this step, these parameters remain uninitialized
   def __post_init__(self):

--- a/tests/db_utils/db_setup.py
+++ b/tests/db_utils/db_setup.py
@@ -9,7 +9,7 @@ from sqlalchemy.schema import ForeignKeyConstraint
 from sqlalchemy.ext.declarative import declarative_base
 
 from aidb.config.config_types import python_type_to_sqlalchemy_type
-from aidb.utils.constants import BLOB_TABLE_NAMES_TABLE
+from aidb.utils.constants import BLOB_TABLE_NAMES_TABLE, table_name_for_rep_and_topk_and_blob_mapping
 from sqlalchemy.sql import text
 from dataclasses import dataclass
 from typing import Optional
@@ -145,6 +145,10 @@ async def insert_data_in_tables(engine, data_dir: str, only_blob_data: bool):
       for column in df.columns:
         column_info = extract_column_info(table_name, column)
         df.rename(columns={column: column_info.name}, inplace=True)
+
+      if table_name.startswith('mapping'):
+        _, _, blob_mapping_table_name = table_name_for_rep_and_topk_and_blob_mapping(['blobs_00'])
+        table_name = blob_mapping_table_name
       # FIXME: in case of mysql, this function doesn't wait, hence throwing integrity error
       await conn.run_sync(lambda conn: df.to_sql(table_name, conn, if_exists='append', index=False))
 

--- a/tests/tasti_test/tasti_test.py
+++ b/tests/tasti_test/tasti_test.py
@@ -36,17 +36,17 @@ class TastiTests():
     self.vd_type = vector_database_type
     self.seed = seed
 
-    self.data, vector_ids = self.generate_data(self.data_size, embedding_dim)
+    self.data, self.vector_ids = self.generate_data(self.data_size, embedding_dim)
     self.user_database = self.simulate_user_providing_database(index_path, weaviate_auth)
 
-    self.tasti = Tasti(index_name, vector_ids, self.user_database, nb_buckets, percent_fpf, seed)
+    self.tasti = Tasti(index_name, self.user_database, nb_buckets, percent_fpf, seed)
 
 
   def generate_data(self, data_size, emb_size):
     np.random.seed(self.seed)
     embeddings = np.random.rand(data_size, emb_size)
     data = pd.DataFrame({'id': range(self.total_data, self.total_data + data_size), 'values': embeddings.tolist()})
-    vector_ids = pd.DataFrame({'id': range(self.total_data, self.total_data + data_size)})
+    vector_ids = pd.DataFrame({'vector_id': range(self.total_data, self.total_data + data_size)})
     self.total_data += data_size
     return data, vector_ids
 
@@ -85,6 +85,7 @@ class TastiTests():
 
 
   def test(self):
+    self.tasti.set_vector_ids(self.vector_ids)
     representative_vector_ids = self.tasti.get_representative_vector_ids()
     print('The shape of cluster representative ids', representative_vector_ids.shape)
     # get culster representatives ids

--- a/tests/test_limit_engine.py
+++ b/tests/test_limit_engine.py
@@ -33,9 +33,8 @@ class LimitEngineTests(IsolatedAsyncioTestCase):
 
     tasti_test = TastiTests(index_name, data_size, embedding_dim, nb_buckets, vector_database_type, index_path='./')
     tasti_index = tasti_test.tasti
-    blob_mapping_table = 'mapping_blobs'
 
-    gt_engine, aidb_engine = await setup_gt_and_aidb_engine(DB_URL, data_dir, tasti_index, blob_mapping_table)
+    gt_engine, aidb_engine = await setup_gt_and_aidb_engine(DB_URL, data_dir, tasti_index)
 
 
     register_inference_services(aidb_engine, data_dir)

--- a/tests/tests_vector_database_setup.py
+++ b/tests/tests_vector_database_setup.py
@@ -29,7 +29,6 @@ def test_equality(value):
 
 
 blob_table_name = 'blob00'
-blob_mapping_table_name = 'blob_mapping_00'
 index_name = 'tasti'
 
 class AidbVectorDatabaseSetupTests(IsolatedAsyncioTestCase):
@@ -39,7 +38,7 @@ class AidbVectorDatabaseSetupTests(IsolatedAsyncioTestCase):
     vd_type = 'FAISS'
     auth = './'
 
-    vector_database = VectorDatabaseSetup(DB_URL, blob_table_name, blob_mapping_table_name, vd_type, index_name, auth)
+    vector_database = VectorDatabaseSetup(DB_URL, blob_table_name, vd_type, index_name, auth)
     await vector_database.setup()
 
     existing_vector_database = FaissVectorDatabase(auth)
@@ -52,7 +51,7 @@ class AidbVectorDatabaseSetupTests(IsolatedAsyncioTestCase):
     vd_type = 'chroma'
     auth = './'
 
-    vector_database = VectorDatabaseSetup(DB_URL, blob_table_name, blob_mapping_table_name, vd_type, index_name, auth)
+    vector_database = VectorDatabaseSetup(DB_URL, blob_table_name, vd_type, index_name, auth)
     await vector_database.setup()
 
     existing_vector_database = ChromaVectorDatabase(auth)
@@ -68,7 +67,7 @@ class AidbVectorDatabaseSetupTests(IsolatedAsyncioTestCase):
     api_key = os.environ.get('WEAVIATE_API_KEY')
     auth = WeaviateAuth(url=url, api_key=api_key)
 
-    vector_database = VectorDatabaseSetup(DB_URL, blob_table_name, blob_mapping_table_name, vd_type, index_name, auth)
+    vector_database = VectorDatabaseSetup(DB_URL, blob_table_name, vd_type, index_name, auth)
     await vector_database.setup()
 
     existing_vector_database = WeaviateVectorDatabase(auth)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,7 @@
 from tests.db_utils.db_setup import create_db, setup_db, setup_config_tables, insert_data_in_tables, clear_all_tables
 from aidb.engine import Engine
 
-async def setup_gt_and_aidb_engine(db_url, data_dir, tasti_index = None, blob_mapping_table_name = None):
+async def setup_gt_and_aidb_engine(db_url, data_dir, tasti_index = None):
   # Set up the ground truth database
   gt_db_fname = 'aidb_gt.sqlite'
   await create_db(db_url, gt_db_fname)
@@ -20,7 +20,6 @@ async def setup_gt_and_aidb_engine(db_url, data_dir, tasti_index = None, blob_ma
   engine = Engine(
     f'{db_url}/{aidb_db_fname}',
     debug=False,
-    blob_mapping_table_name=blob_mapping_table_name,
     tasti_index=tasti_index
   )
 


### PR DESCRIPTION
1. Enforce the blob mapping table name based on related blob tables
2. Select the vector ids from the blob mapping table to establish the default set for TASTI index. Users may also opt for a specific subset of these vector ids.