### PR TITLE
Fix python version in setup for numba errors

### DIFF
--- a/aidb/vector_database/tasti.py
+++ b/aidb/vector_database/tasti.py
@@ -4,6 +4,12 @@ from typing import Optional
 
 from aidb.vector_database.vector_database_config import TastiConfig
 
+def _get_and_update_dists_shared(x, i, min_dists, embeddings):
+  dists = np.sqrt(np.sum((x - embeddings[i]) ** 2))
+  if dists < min_dists[i]:
+    min_dists[i] = dists
+
+
 def get_and_update_dists(x: np.ndarray, embeddings: np.ndarray, min_dists: np.ndarray):
   '''
   :param x: embedding of cluster representatives
@@ -17,17 +23,13 @@ def get_and_update_dists(x: np.ndarray, embeddings: np.ndarray, min_dists: np.nd
     def _get_and_update_dists_numba(x: np.ndarray, embeddings: np.ndarray, min_dists: np.ndarray):
 
       for i in prange(len(embeddings)):
-        dists = np.sqrt(np.sum((x - embeddings[i]) ** 2))
-        if dists < min_dists[i]:
-          min_dists[i] = dists
+        _get_and_update_dists_shared(x, i, min_dists, embeddings)
     _get_and_update_dists_numba(x, embeddings, min_dists)
 
   except:
     def _get_and_update_dists_no_numba(x: np.ndarray, embeddings: np.ndarray, min_dists: np.ndarray):
       for i in range(len(embeddings)):
-        dists = np.sqrt(np.sum((x - embeddings[i]) ** 2))
-        if dists < min_dists[i]:
-          min_dists[i] = dists
+        _get_and_update_dists_shared(x, i, min_dists, embeddings)
     _get_and_update_dists_no_numba(x, embeddings, min_dists)
 
 

--- a/aidb/vector_database/tasti.py
+++ b/aidb/vector_database/tasti.py
@@ -20,17 +20,17 @@ def get_and_update_dists(x: np.ndarray, embeddings: np.ndarray, min_dists: np.nd
     from numba import njit, prange
 
     @njit(parallel=True)
-    def _get_and_update_dists_numba(x: np.ndarray, embeddings: np.ndarray, min_dists: np.ndarray):
+    def _get_and_update_dists(x: np.ndarray, embeddings: np.ndarray, min_dists: np.ndarray):
 
       for i in prange(len(embeddings)):
         _get_and_update_dists_shared(x, i, min_dists, embeddings)
-    _get_and_update_dists_numba(x, embeddings, min_dists)
 
   except:
-    def _get_and_update_dists_no_numba(x: np.ndarray, embeddings: np.ndarray, min_dists: np.ndarray):
+    def _get_and_update_dists(x: np.ndarray, embeddings: np.ndarray, min_dists: np.ndarray):
       for i in range(len(embeddings)):
         _get_and_update_dists_shared(x, i, min_dists, embeddings)
-    _get_and_update_dists_no_numba(x, embeddings, min_dists)
+  
+  _get_and_update_dists(x, embeddings, min_dists)
 
 
 class Tasti(TastiConfig):

--- a/aidb/vector_database/tasti.py
+++ b/aidb/vector_database/tasti.py
@@ -4,11 +4,6 @@ from typing import Optional
 
 from aidb.vector_database.vector_database_config import TastiConfig
 
-def _get_and_update_dists_shared(x, i, min_dists, embeddings):
-  dists = np.sqrt(np.sum((x - embeddings[i]) ** 2))
-  if dists < min_dists[i]:
-    min_dists[i] = dists
-
 
 def get_and_update_dists(x: np.ndarray, embeddings: np.ndarray, min_dists: np.ndarray):
   '''
@@ -16,6 +11,11 @@ def get_and_update_dists(x: np.ndarray, embeddings: np.ndarray, min_dists: np.nd
   :param embeddings: embeddings of all data
   :min_dists: array to record the minimum distance for each embedding to the embedding of cluster representatives
   '''
+  def _get_and_update_dists_shared(x, i, min_dists, embeddings):
+    dists = np.sqrt(np.sum((x - embeddings[i]) ** 2))
+    if dists < min_dists[i]:
+      min_dists[i] = dists
+
   try:
     from numba import njit, prange
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
   author_email="daniel.d.kang@gmail.com",
   # Packages
   packages=find_packages(include=["aidb", "aidb.*", "aidb_utilities", "aidb_utilities.*"]),
-  python_requires=">=3.9",
+  python_requires=">=3.9,<3.12",
   install_requires=required,
   classifiers=[
     "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
   author_email="daniel.d.kang@gmail.com",
   # Packages
   packages=find_packages(include=["aidb", "aidb.*", "aidb_utilities", "aidb_utilities.*"]),
-  python_requires=">=3.9,<3.12",
+  python_requires=">=3.9",
   install_requires=required,
   classifiers=[
     "Intended Audience :: Developers",


### PR DESCRIPTION
**Description**: As per the issue given [here](https://github.com/ddkang/aidb/issues/105), numba requires python version <3.12 and >=3.8.  According to the [PEP 440 version specifiers](https://peps.python.org/pep-0440/#version-specifiers), I have added `<3.12` in the `setup` function in `setup.py` file. 

**Note**: The installation will still have the issue, but now the setup will have python version requirements so users can change versions accordingly.