### PR TITLE
Replace 'read_sql' with 'read_sql_query'.

### DIFF
--- a/aidb/engine/approx_aggregate_engine.py
+++ b/aidb/engine/approx_aggregate_engine.py
@@ -161,7 +161,7 @@ class ApproximateAggregateEngine(FullScanEngine):
           new_query
       )
 
-      input_df = await conn.run_sync(lambda conn: pd.read_sql(text(query_add_filter_key.sql_str), conn))
+      input_df = await conn.run_sync(lambda conn: pd.read_sql_query(text(query_add_filter_key.sql_str), conn))
       await bound_service.infer(input_df)
       inference_services_executed.add(bound_service.service.name)
 
@@ -188,7 +188,7 @@ class ApproximateAggregateEngine(FullScanEngine):
                   GROUP BY {', '.join(selected_column)}
                  '''
 
-    res_df = await conn.run_sync(lambda conn: pd.read_sql(text(query_str), conn))
+    res_df = await conn.run_sync(lambda conn: pd.read_sql_query(text(query_str), conn))
     res_df[WEIGHT_COL_NAME] = 1. / self.blob_count
     res_df[MASS_COL_NAME] = 1
 
@@ -204,7 +204,7 @@ class ApproximateAggregateEngine(FullScanEngine):
       conn
   ):
     sample_blobs_query_str = self.get_sample_blobs_query(blob_tables, num_samples, blob_key_filtering_predicates_str)
-    sample_blobs_df = await conn.run_sync(lambda conn: pd.read_sql(text(sample_blobs_query_str), conn))
+    sample_blobs_df = await conn.run_sync(lambda conn: pd.read_sql_query(text(sample_blobs_query_str), conn))
 
     if len(sample_blobs_df) < num_samples:
       raise Exception(f'Require {num_samples} samples, but only get {len(sample_blobs_df)} samples')

--- a/aidb/engine/approx_select_engine.py
+++ b/aidb/engine/approx_select_engine.py
@@ -39,7 +39,7 @@ class ApproxSelectEngine(TastiEngine):
       inp_query_str = self.get_input_query_for_inference_service_filtered_index(bound_service,
                                                                                 self.blob_mapping_table_name,
                                                                                 sampled_index)
-      inp_df = await conn.run_sync(lambda conn: pd.read_sql(text(inp_query_str), conn))
+      inp_df = await conn.run_sync(lambda conn: pd.read_sql_query(text(inp_query_str), conn))
       inp_df.set_index(VECTOR_ID_COLUMN, inplace=True, drop=True)
       await bound_service.infer(inp_df)
 
@@ -76,7 +76,7 @@ class ApproxSelectEngine(TastiEngine):
         query_no_where
     )
 
-    all_df = await conn.run_sync(lambda conn: pd.read_sql(text(all_query_add_filter_key.sql_str), conn))
+    all_df = await conn.run_sync(lambda conn: pd.read_sql_query(text(all_query_add_filter_key.sql_str), conn))
     # drop duplicated columns, this will happen when 'select *'
     all_df = all_df.loc[:, ~all_df.columns.duplicated()]
     all_df.set_index(VECTOR_ID_COLUMN, inplace=True, drop=True)
@@ -87,7 +87,7 @@ class ApproxSelectEngine(TastiEngine):
         query_after_adding_join
     )
 
-    res_df = await conn.run_sync(lambda conn: pd.read_sql(text(sample_query_add_filter_key.sql_str), conn))
+    res_df = await conn.run_sync(lambda conn: pd.read_sql_query(text(sample_query_add_filter_key.sql_str), conn))
     # We need to add '__vector_id' in SELECT clause. When 'SELECT *', there will be two '__vector_id' columns.
     # So we need to drop duplicated columns
     res_df = res_df.loc[:, ~res_df.columns.duplicated()]

--- a/aidb/engine/full_scan_engine.py
+++ b/aidb/engine/full_scan_engine.py
@@ -20,7 +20,7 @@ class FullScanEngine(BaseEngine):
                                                                                 inference_services_executed)
 
       async with self._sql_engine.begin() as conn:
-        inp_df = await conn.run_sync(lambda conn: pd.read_sql(text(inp_query_str), conn))
+        inp_df = await conn.run_sync(lambda conn: pd.read_sql_query(text(inp_query_str), conn))
 
       # The bound inference service is responsible for populating the database
       await bound_service.infer(inp_df)

--- a/aidb/engine/limit_engine.py
+++ b/aidb/engine/limit_engine.py
@@ -48,7 +48,7 @@ class LimitEngine(TastiEngine):
                                                                                   self.blob_mapping_table_name,
                                                                                   [index])
         async with self._sql_engine.begin() as conn:
-          inp_df = await conn.run_sync(lambda conn: pd.read_sql(text(inp_query_str), conn))
+          inp_df = await conn.run_sync(lambda conn: pd.read_sql_query(text(inp_query_str), conn))
         inp_df.set_index(VECTOR_ID_COLUMN, inplace=True, drop=True)
         await bound_service.infer(inp_df)
 

--- a/aidb/engine/tasti_engine.py
+++ b/aidb/engine/tasti_engine.py
@@ -49,13 +49,13 @@ class TastiEngine(FullScanEngine):
     for bound_service in bound_service_list:
       inp_query_str = self.get_input_query_for_inference_service_filtered_index(bound_service, self.rep_table_name)
       async with self._sql_engine.begin() as conn:
-        inp_df = await conn.run_sync(lambda conn: pd.read_sql(text(inp_query_str), conn))
+        inp_df = await conn.run_sync(lambda conn: pd.read_sql_query(text(inp_query_str), conn))
       inp_df.set_index(VECTOR_ID_COLUMN, inplace=True, drop=True)
       await bound_service.infer(inp_df)
 
     score_query_str, score_connected = self.get_score_query_str(query, self.rep_table_name)
     async with self._sql_engine.begin() as conn:
-      score_df = await conn.run_sync(lambda conn: pd.read_sql(text(score_query_str), conn))
+      score_df = await conn.run_sync(lambda conn: pd.read_sql_query(text(score_query_str), conn))
     score_df.set_index(VECTOR_ID_COLUMN, inplace=True, drop=True)
 
     # One index may appear multi times, like there are two objects in one blob, we get average value for this blob
@@ -112,7 +112,7 @@ class TastiEngine(FullScanEngine):
   async def propagate_score_for_all_vector_ids(self, score_df: pd.DataFrame, return_binary_score = False) -> pd.DataFrame:
     topk_query_str = f'SELECT * FROM {self.topk_table_name}'
     async with self._sql_engine.begin() as conn:
-      topk_df = await conn.run_sync(lambda conn: pd.read_sql(text(topk_query_str), conn))
+      topk_df = await conn.run_sync(lambda conn: pd.read_sql_query(text(topk_query_str), conn))
     topk_df.set_index(VECTOR_ID_COLUMN, inplace=True, drop=True)
 
     topk = len(topk_df.columns) // 2
@@ -222,7 +222,7 @@ class TastiEngine(FullScanEngine):
                                     '''
 
       async with self._sql_engine.begin() as conn:
-        vector_ids = await conn.run_sync(lambda conn: pd.read_sql(text(vector_id_select_query_str), conn))
+        vector_ids = await conn.run_sync(lambda conn: pd.read_sql_query(text(vector_id_select_query_str), conn))
     self.tasti_index.set_vector_ids(vector_ids)
 
     rep_ids = self.tasti_index.get_representative_vector_ids()
@@ -238,7 +238,7 @@ class TastiEngine(FullScanEngine):
 
     async with self._sql_engine.begin() as conn:
       await conn.run_sync(lambda conn: self._create_tasti_table(topk, conn))
-      rep_blob_df = await conn.run_sync(lambda conn: pd.read_sql(text(rep_blob_query_str), conn))
+      rep_blob_df = await conn.run_sync(lambda conn: pd.read_sql_query(text(rep_blob_query_str), conn))
       # FIXME: same as db_setup.py line 147, in case of mysql,
       #  this function doesn't wait, hence throwing integrity error
       await conn.run_sync(lambda conn: rep_blob_df.to_sql(self.rep_table_name, conn, if_exists='append', index=False))

--- a/aidb/inference/bound_inference_service.py
+++ b/aidb/inference/bound_inference_service.py
@@ -173,7 +173,7 @@ class CachedBoundInferenceService(BoundInferenceService):
     """
     checks the presence of inputs in the cache table
     """
-    cache_entries = await conn.run_sync(lambda conn: pd.read_sql(text(str(self._cache_query_stub.compile())), conn))
+    cache_entries = await conn.run_sync(lambda conn: pd.read_sql_query(text(str(self._cache_query_stub.compile())), conn))
     cache_entries = cache_entries.set_index([col.name for col in self._cache_columns])
     normalized_cache_cols = [self.convert_cache_column_name_to_normalized_column_name(col.name) for col in
                              self._cache_columns]
@@ -209,7 +209,7 @@ class CachedBoundInferenceService(BoundInferenceService):
                 self.binding.input_columns]
             )
           )
-          df = await conn.run_sync(lambda conn: pd.read_sql(query, conn))
+          df = await conn.run_sync(lambda conn: pd.read_sql_query(query, conn))
           results.append(df)
         else:
           inference_results = self.service.infer_one(inp_row)


### PR DESCRIPTION
Fix the error caused by 'read_sql' in PostgreSQL -> Use 'read_sql_query' instead.

'read_sql' is a convenience wrapper around read_sql_table and read_sql_query.
In PostgreSQL, using read_sql can lead to an sqlalchemy.exc.DBAPIError. I think the driver of PostgreSQL might have compatibility issues with 'read_sql'.