### PR TITLE
fix data type length

### DIFF
--- a/aidb/engine/tasti_engine.py
+++ b/aidb/engine/tasti_engine.py
@@ -173,7 +173,7 @@ class TastiEngine(FullScanEngine):
     columns.append(sqlalchemy.Column(VECTOR_ID_COLUMN, sqlalchemy.Integer, primary_key=True, autoincrement=False))
     for i in range(topk):
       columns.append(sqlalchemy.Column(f'topk_reps_{str(i)}', sqlalchemy.Integer))
-      columns.append(sqlalchemy.Column(f'topk_dists_{str(i)}', sqlalchemy.Float))
+      columns.append(sqlalchemy.Column(f'topk_dists_{str(i)}', sqlalchemy.Float(32)))
     topk_table = sqlalchemy.schema.Table(self.topk_table_name, metadata, *columns)
     metadata.create_all(conn)
 

--- a/tests/db_utils/db_setup.py
+++ b/tests/db_utils/db_setup.py
@@ -90,7 +90,7 @@ async def setup_db(db_url: str, db_name: str, data_dir: str):
             if column_info.is_primary_key or column_info.refers_to:
               column_info.dtype = sqlalchemy.VARCHAR(256)
             else:
-              column_info.dtype = sqlalchemy.TEXT
+              column_info.dtype = sqlalchemy.VARCHAR(2048)
           else:
             column_info.dtype = dtype
           columns_info.append(column_info)


### PR DESCRIPTION
- [x] Modify data type from TEXT to VARCHAR(2048) as mentioned in PR #151 
- [x] Set a specific number of decimal places for the 'topk' table to ensure consistency across different databases, as MySQL truncates data to 6 decimal places by default, potentially leading to varying results.