### PR TITLE
fix run time error

### DIFF
--- a/aidb/engine/engine.py
+++ b/aidb/engine/engine.py
@@ -29,3 +29,5 @@ class Engine(LimitEngine, ApproximateAggregateEngine, NonSelectQueryEngine, Appr
       return result
     except Exception as e:
       raise e
+    finally:
+      self.__del__()


### PR DESCRIPTION
When encountering an exception and using the keyboard to terminate the engine, a 'RuntimeError: Event loop is closed' occurs. This issue also arises while running user-defined asynchronous functions in PostgreSQL database and MySQL database, stemming from the engine not being properly disposed. I've identified one potential solution to address this, I'm not sure whether a better solution exists.






