### PR TITLE
fix logical operator parsing in filtering predicates

### DIFF
--- a/aidb/engine/base_engine.py
+++ b/aidb/engine/base_engine.py
@@ -239,8 +239,8 @@ class BaseEngine():
   def _get_where_str(self, filtering_predicates):
     and_connected = []
     for fp in filtering_predicates:
-      and_connected.append(' OR '.join(
-        [p.sql() for p in fp]))
+      and_connected.append(' OR '.join([p.sql() for p in fp]))
+    and_connected = [f'({or_connected})' for or_connected in and_connected]
     return ' AND '.join(and_connected)
 
 

--- a/tests/tests_full_scan_engine.py
+++ b/tests/tests_full_scan_engine.py
@@ -33,6 +33,45 @@ class FullScanEngineTests(IsolatedAsyncioTestCase):
     queries = [
       (
         'full_scan',
+        '''
+        SELECT *
+        FROM objects00
+        WHERE (frame >= 100 AND frame <= 300) OR (x_min < 100 AND y_min > 600) AND NOT (frame >= 2000)
+        ''',
+        '''
+        SELECT *
+        FROM objects00
+        WHERE (frame >= 100 AND frame <= 300) OR (x_min < 100 AND y_min > 600) AND NOT (frame >= 2000)
+        '''
+      ),
+      (
+        'full_scan',
+        '''
+        SELECT frame
+        FROM objects00
+        WHERE objects00.frame > 200 OR objects00.frame = 700 AND objects00.frame = 1000 OR objects00.frame = 1
+        ''',
+        '''
+        SELECT frame
+        FROM objects00
+        WHERE objects00.frame > 200 OR objects00.frame = 700 AND objects00.frame = 1000 OR objects00.frame = 1
+        '''
+      ),
+      (
+        'full_scan',
+        '''
+        SELECT *
+        FROM objects00
+        WHERE (x_max > 500 OR (y_min < 250 AND y_max > 750)) AND NOT (frame >= 300 OR frame <= 800)   
+        ''',
+        '''
+        SELECT *
+        FROM objects00
+        WHERE (x_max > 500 OR (y_min < 250 AND y_max > 750)) AND NOT (frame >= 300 OR frame <= 800)   
+        '''
+      ),
+      (
+        'full_scan',
         '''SELECT * FROM objects00 WHERE object_name='car' AND frame < 100;''',
         '''SELECT * FROM objects00 WHERE object_name='car' AND frame < 100;'''
       ),
@@ -58,10 +97,10 @@ class FullScanEngineTests(IsolatedAsyncioTestCase):
       ),
       (
         'full_scan',
-        '''SELECT * FROM objects00 join colors02 on objects00.frame = colors02.frame 
+        '''SELECT * FROM objects00 join colors02 on objects00.frame = colors02.frame
            and objects00.object_id = colors02.object_id;''',
 
-        '''SELECT * FROM objects00 join colors02 on objects00.frame = colors02.frame 
+        '''SELECT * FROM objects00 join colors02 on objects00.frame = colors02.frame
            and objects00.object_id = colors02.object_id;'''
       ),
       (
@@ -89,7 +128,6 @@ class FullScanEngineTests(IsolatedAsyncioTestCase):
            FROM colors02 JOIN objects00 table2 ON colors02.frame = table2.frame
            WHERE color = 'blue' AND x_min > 600;'''
       )
-
     ]
 
     db_url_list = [MYSQL_URL, SQLITE_URL, POSTGRESQL_URL]


### PR DESCRIPTION
Fix issue #143 

- [x] Correct the handling of logical operators to properly reflect their precedence. The priority is 'NOT' > 'AND' > 'OR'. 
- [x] Fix the issue of incorrect priority when regenerating queries. 'fp1 OR fp2 AND fp3 OR fp4' -> '(fp1 OR fp2) AND (fp3 OR fp4)
- [x] Resolve the issue where 'NOT' is incorrectly parsed. Previous: {fp1: NOT (A OR B)}, parsing result: fp1 -> Now:  {fp1: A, fp2: B}, parsing result: ~(fp1 | fp2)