### PR TITLE
Fix inference bug when there are NULL in columns

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -12,6 +12,7 @@ from aidb.utils.asyncio import asyncio_run
 
 def setup_blob_tables(config):
   input_blobs = pd.read_csv(config.blobs_csv_file)
+  input_blobs = input_blobs.fillna("")
   base_table_setup = BaseTablesSetup(f"{config.DB_URL}/{config.DB_NAME}")
   base_table_setup.insert_blob_meta_data(config.blob_table_name, input_blobs, config.blobs_keys_columns)
 


### PR DESCRIPTION
The problem in issue #104 seems to be caused by having NaN in the dataframe, which is not possible to transformed into json. By replacing the NaN in the dataframe with empty string should fix the issue.

P.S. I cannot really reproduce the problem since the blank place in the given table are not really null, instead are wrongly recognized strings starts with character '='. However, after searching on stackoverflow I believe the fix should resolve the issue.