### PR TITLE
Fix unclosed event loop

### DIFF
--- a/aidb/utils/asyncio.py
+++ b/aidb/utils/asyncio.py
@@ -8,7 +8,9 @@ def asyncio_run(future, as_task=True):
     loop = asyncio.get_running_loop()
   except RuntimeError:  # no event loop running
     loop = asyncio.new_event_loop()
-    return loop.run_until_complete(_to_task(future, as_task, loop))
+    ret = loop.run_until_complete(_to_task(future, as_task, loop))
+    loop.close()
+    return ret
   else:
     nest_asyncio.apply(loop)
     return asyncio.run(_to_task(future, as_task, loop))


### PR DESCRIPTION
For most cases, the unclosed event loop mentioned in #92 seems to come from the newly created event loop in https://github.com/ddkang/aidb/blob/a6589a451d25d9bdc8d022e584bf0b97b5e826d8/aidb/utils/asyncio.py#L10. 
I tried to close this loop immediately after the execution finished. The warnings does not pop out again when I'm testing this, but I'm not sure whether there will be any side effects of this.