### PR TITLE
add ordering optimization

### DIFF
--- a/aidb/engine/base_engine.py
+++ b/aidb/engine/base_engine.py
@@ -73,6 +73,7 @@ class BaseEngine():
       pp.install_extras(
         exclude=['django', 'ipython', 'ipython_repr_pretty'])
       pp.pprint(config)
+      print(config.blob_tables)
 
     return config
 

--- a/aidb/engine/base_engine.py
+++ b/aidb/engine/base_engine.py
@@ -73,7 +73,6 @@ class BaseEngine():
       pp.install_extras(
         exclude=['django', 'ipython', 'ipython_repr_pretty'])
       pp.pprint(config)
-      print(config.blob_tables)
 
     return config
 
@@ -214,7 +213,7 @@ class BaseEngine():
     return join_path_str
 
 
-  def _get_select_join_str(self, bound_service: BoundInferenceService, filtering_predicate_tables: Optional[List] = None, vector_id_table: Optional[str] = None):
+  def _get_select_join_str(self, bound_service: BoundInferenceService, filtering_predicate_tables: Optional[List] = [], vector_id_table: Optional[str] = None):
     column_to_root_column = self._config.columns_to_root_column
     binding = bound_service.binding
     inp_cols = binding.input_columns
@@ -265,7 +264,6 @@ class BaseEngine():
     # filtering predicates that can be satisfied by the currently executed inference engines
     filtering_predicates_satisfied = []
     filtering_predicates_tables = []
-    print(266, filtering_predicates, inference_engines_required_for_filtering_predicates, tables_in_filtering_predicates)
     for p, e, t in zip(filtering_predicates, inference_engines_required_for_filtering_predicates,
                        tables_in_filtering_predicates):
       if len(already_executed_inference_services.intersection(e)) == len(e):
@@ -275,7 +273,6 @@ class BaseEngine():
             filtering_predicates_tables.append(table)
         
     inp_tables, select_join_str = self._get_select_join_str(bound_service, filtering_predicates_tables)
-    print(278, filtering_predicates_tables, select_join_str)
     where_str = self._get_where_str(filtering_predicates_satisfied)
 
     if len(filtering_predicates_satisfied) > 0:

--- a/aidb/engine/full_scan_engine.py
+++ b/aidb/engine/full_scan_engine.py
@@ -54,7 +54,6 @@ class FullScanEngine(TastiEngine):
 
       async with self._sql_engine.begin() as conn:
         inp_df = await conn.run_sync(lambda conn: pd.read_sql_query(text(inp_query_str), conn))
-      inp_df.to_csv(f'inp_df_{bound_service.service.name}.csv')
 
       # The bound inference service is responsible for populating the database
       await bound_service.infer(inp_df)

--- a/aidb/engine/full_scan_engine.py
+++ b/aidb/engine/full_scan_engine.py
@@ -1,14 +1,14 @@
-import pandas as pd
-from sqlalchemy.sql import text
-from typing import List
 from collections import defaultdict
+from typing import List
 
+import pandas as pd
 from aidb.engine.base_engine import BaseEngine
 from aidb.query.query import Query
+from aidb.utils.logger import logger
 from aidb.utils.order_optimization_utils import (
-  get_currently_supported_filtering_predicates_for_ordering, 
-  reorder_inference_engine
-)
+    get_currently_supported_filtering_predicates_for_ordering,
+    reorder_inference_engine)
+from sqlalchemy.sql import text
 
 RETRIEVAL_BATCH_SIZE = 10000
 
@@ -42,8 +42,9 @@ class FullScanEngine(BaseEngine):
         adjusted_query = Query(adjusted_query, self._config)
         proxy_score_for_all_blobs = await self.get_proxy_scores_for_all_blobs(adjusted_query, return_binary_score=True)
         engine_to_proxy_score[engine] = proxy_score_for_all_blobs.sum() / len(proxy_score_for_all_blobs)
-
+      logger.info(f'Proxy scores for all engines: {engine_to_proxy_score}')
       bound_service_list = reorder_inference_engine(engine_to_proxy_score, bound_service_list)
+      logger.info(f'The order of inference engines: {bound_service_list}')
       
     inference_services_executed = set()
     for bound_service in bound_service_list:

--- a/aidb/engine/full_scan_engine.py
+++ b/aidb/engine/full_scan_engine.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from typing import List
 
 import pandas as pd
-from aidb.engine.base_engine import BaseEngine
+from aidb.engine.tasti_engine import TastiEngine
 from aidb.query.query import Query
 from aidb.utils.logger import logger
 from aidb.utils.order_optimization_utils import (
@@ -14,7 +14,7 @@ RETRIEVAL_BATCH_SIZE = 10000
 
 
           
-class FullScanEngine(BaseEngine):
+class FullScanEngine(TastiEngine):
   async def execute_full_scan(self, query: Query, **kwargs):
     '''
     Executes a query by doing a full scan and returns the results.

--- a/aidb/engine/full_scan_engine.py
+++ b/aidb/engine/full_scan_engine.py
@@ -1,34 +1,53 @@
 import pandas as pd
 from sqlalchemy.sql import text
 from typing import List
+from collections import defaultdict
 
 from aidb.engine.base_engine import BaseEngine
 from aidb.query.query import Query
+from aidb.utils.order_optimization_utils import (
+  get_currently_supported_filtering_predicates_for_ordering, 
+  reorder_inference_engine
+)
 
 RETRIEVAL_BATCH_SIZE = 10000
 
 
+          
 class FullScanEngine(BaseEngine):
   async def execute_full_scan(self, query: Query, **kwargs):
     '''
     Executes a query by doing a full scan and returns the results.
     '''
     # The query is irrelevant since we do a full scan anyway
+    
+    bound_service_list = query.inference_engines_required_for_query
+    supported_filtering_predicates = get_currently_supported_filtering_predicates_for_ordering(self._config, query)
+    engine_to_proxy_score = {}
+    bound_service_list = query.inference_engines_required_for_query
+    for engine, related_predicates in supported_filtering_predicates.items():
+      engine_fp = self._get_where_str(related_predicates)
+      adjusted_query = f'select * from {engine} WHERE {engine_fp}'
+      adjusted_query = Query(adjusted_query, self._config)
+      # proxy_score_for_all_blobs = await self.get_proxy_scores_for_all_blobs(adjusted_query, return_binary_score=True)
+      # engine_to_proxy_score[engine] = proxy_score_for_all_blobs.sum() / len(proxy_score_for_all_blobs)
+      engine_to_proxy_score[engine] = 1
+    bound_service_list = reorder_inference_engine(engine_to_proxy_score, bound_service_list)
     is_udf_query = query.is_udf_query
     if is_udf_query:
       query.check_udf_query_validity()
       dataframe_sql, query = query.udf_query
 
-    bound_service_list = query.inference_engines_required_for_query
     inference_services_executed = set()
     for bound_service in bound_service_list:
+      print(70, bound_service)
       inp_query_str = self.get_input_query_for_inference_service_filter_service(bound_service,
                                                                                 query,
                                                                                 inference_services_executed)
-
+      print(73, inp_query_str)
       async with self._sql_engine.begin() as conn:
         inp_df = await conn.run_sync(lambda conn: pd.read_sql_query(text(inp_query_str), conn))
-
+      print(76, inp_df)
       # The bound inference service is responsible for populating the database
       await bound_service.infer(inp_df)
 

--- a/aidb/engine/full_scan_engine.py
+++ b/aidb/engine/full_scan_engine.py
@@ -25,7 +25,7 @@ class FullScanEngine(TastiEngine):
     if is_udf_query:
       query.check_udf_query_validity()
       dataframe_sql, query = query.udf_query
-      
+
     bound_service_list = query.inference_engines_required_for_query
     if self.tasti_index:
       supported_filtering_predicates = get_currently_supported_filtering_predicates_for_ordering(self._config, query)

--- a/aidb/inference/bound_inference_service.py
+++ b/aidb/inference/bound_inference_service.py
@@ -216,9 +216,11 @@ class CachedBoundInferenceService(BoundInferenceService):
     # Drop duplicate inputs
     inputs_drop_duplicates = inputs.drop_duplicates()
     # Note: the input columns are assumed to be in order
+    logger.info(f'{self.service.name} Require {len(inputs_drop_duplicates)} inputs')
     async with self._engine.begin() as conn:
       inputs_not_in_cache, inputs_not_in_cache_primary_cols, inputs_in_cache_primary_df = \
           await self._get_inputs_not_in_cache_table(inputs_drop_duplicates, conn)
+      logger.info(f'Inferencing {len(inputs_not_in_cache)} inputs')
       records_to_insert_in_table = []
       bs = self.service.preferred_batch_size
       input_batches = [inputs_not_in_cache.iloc[i:i + bs] for i in range(0, len(inputs_not_in_cache), bs)]

--- a/aidb/query/query.py
+++ b/aidb/query/query.py
@@ -473,6 +473,21 @@ class Query(object):
 
 
   @cached_property
+  def columns_in_filtering_predicate(self):
+    """
+    Columns needed to satisfy the columns present in each filtering predicate
+    for e.g. if predicates are [color=red, frame>20, object_class=car]
+    it returns [color, frame, object_class]
+    """
+    columns_required_for_filtering_predicates = defaultdict(set)
+    for connected_by_or_filtering_predicate in self.filtering_predicates:
+      for filtering_predicate in connected_by_or_filtering_predicate:
+        for column in filtering_predicate.find_all(exp.Column):
+          columns_required_for_filtering_predicates[filtering_predicate].add(column.sql())
+    return columns_required_for_filtering_predicates
+  
+  
+  @cached_property
   def inference_engines_required_for_query(self):
     """
     Inference services required for sql query, will return a list of inference service

--- a/aidb/utils/order_optimization_utils.py
+++ b/aidb/utils/order_optimization_utils.py
@@ -1,0 +1,47 @@
+from aidb.config.config import Config
+from aidb.query.query import Query
+from collections import defaultdict
+
+
+def get_currently_supported_filtering_predicates_for_ordering(config: Config, query: Query):
+  inference_engines_on_blob_ids = []
+  all_columns_produced_by_blob_inference = {}
+  for bound_inference_service in query.inference_engines_required_for_query:
+    input_columns = bound_inference_service.binding.input_columns
+    output_columns = bound_inference_service.binding.output_columns
+    if all([input_column.split('.')[0] in config.blob_tables for input_column in input_columns]):
+      inference_engines_on_blob_ids.append(bound_inference_service)
+      for output_column in output_columns:
+        all_columns_produced_by_blob_inference[output_column] = bound_inference_service
+  supported_filtering_predicates = defaultdict(list)
+  for connected_by_or_filtering_predicate in query.filtering_predicates:
+    inference_engine_needed = set()
+    for filtering_predicate in connected_by_or_filtering_predicate:
+      for col in query.columns_in_filtering_predicate[filtering_predicate]:
+        if col in all_columns_produced_by_blob_inference:
+          inference_engine_needed.add(all_columns_produced_by_blob_inference[col])
+    if len(inference_engine_needed) == 1:
+      inference_engine = list(inference_engine_needed)[0]
+      if inference_engine in inference_engines_on_blob_ids:
+        supported_filtering_predicates[inference_engine].append(connected_by_or_filtering_predicate)
+  return supported_filtering_predicates
+
+
+def reorder_inference_engine(engine_to_proxy_score, static_order):
+  engines_with_proxy_score_0 = []
+  engine_scores = []
+  for engine, score in engine_to_proxy_score.items():
+    if engine.service.cost == 0:
+      engines_with_proxy_score_0.append((engine, 0))
+    elif score == 0:
+      engines_with_proxy_score_0.append((engine, engine.service.cost))
+    else:
+      engine_scores.append((engine, engine.service.cost * score))
+      
+  engine_scores.sort(key=lambda a: a[1])
+  engines_with_proxy_score_0.sort(key=lambda a: a[1])
+  ordered_engines = [e for e, s in engines_with_proxy_score_0] + [e for e, s in engine_scores]
+  for e in static_order:
+    if e not in ordered_engines:
+      ordered_engines.append(e)
+  return ordered_engines

--- a/aidb/utils/order_optimization_utils.py
+++ b/aidb/utils/order_optimization_utils.py
@@ -1,6 +1,7 @@
+from collections import defaultdict
+
 from aidb.config.config import Config
 from aidb.query.query import Query
-from collections import defaultdict
 
 
 def get_currently_supported_filtering_predicates_for_ordering(config: Config, query: Query):
@@ -40,6 +41,7 @@ def reorder_inference_engine(engine_to_proxy_score, static_order):
       
   engine_scores.sort(key=lambda a: a[1])
   engines_with_proxy_score_0.sort(key=lambda a: a[1])
+  # TODO: Add support for cached engines
   ordered_engines = [e for e, s in engines_with_proxy_score_0] + [e for e, s in engine_scores]
   for e in static_order:
     if e not in ordered_engines:

--- a/tests/inference_service_utils/http_inference_service_setup.py
+++ b/tests/inference_service_utils/http_inference_service_setup.py
@@ -50,7 +50,7 @@ def run_server(data_dir: str, port=8000):
       service_name = inp.url.path.split('/')[-1]
       inp = await inp.json()
       df = name_to_df[service_name]
-
+      df = df.fillna('Missing')
       # Construct a DataFrame from the input
       inp_df = pd.DataFrame({col: [inp[col]] if not isinstance(inp[col], list) else inp[col]
                              for col in name_to_input_cols[service_name]})
@@ -64,8 +64,8 @@ def run_server(data_dir: str, port=8000):
       res_df_list = []
       for _, group in grouped:
         group = group.drop(columns=name_to_input_cols[service_name]).dropna()
+        group = group.replace('Missing', None)
         res_df_list.append(group.to_dict(orient='list'))
-
       return res_df_list
 
 

--- a/tests/inference_service_utils/http_inference_service_setup.py
+++ b/tests/inference_service_utils/http_inference_service_setup.py
@@ -50,7 +50,6 @@ def run_server(data_dir: str, port=8000):
       service_name = inp.url.path.split('/')[-1]
       inp = await inp.json()
       df = name_to_df[service_name]
-      df = df.fillna('Missing')
       # Construct a DataFrame from the input
       inp_df = pd.DataFrame({col: [inp[col]] if not isinstance(inp[col], list) else inp[col]
                              for col in name_to_input_cols[service_name]})
@@ -59,12 +58,12 @@ def run_server(data_dir: str, port=8000):
       # Note: We're using a left join to ensure that all inputs have corresponding outputs,
       #     with absent outputs represented as None
       result_df = pd.merge(inp_df, df, how='left', on=name_to_input_cols[service_name]).convert_dtypes()
+      output_cols = [col for col in df.columns if col not in name_to_input_cols[service_name]]
       # The outputs are grouped by input dataframe's primary key
       grouped = result_df.groupby(name_to_input_cols[service_name])
       res_df_list = []
       for _, group in grouped:
-        group = group.drop(columns=name_to_input_cols[service_name]).dropna()
-        group = group.replace('Missing', None)
+        group = group.drop(columns=name_to_input_cols[service_name]).dropna(subset=output_cols, how='all')
         res_df_list.append(group.to_dict(orient='list'))
       return res_df_list
 

--- a/tests/inference_service_utils/inference_service_setup.py
+++ b/tests/inference_service_utils/inference_service_setup.py
@@ -7,7 +7,7 @@ from aidb.engine import Engine
 from aidb.inference.http_inference_service import HTTPInferenceService
 
 
-def register_inference_services(engine: Engine, data_dir: str, port=8000, batch_supported=True, preferred_batch_size=128):
+def register_inference_services(engine: Engine, data_dir: str, port=8000, batch_supported=True, preferred_batch_size=128, cost_dict={}):
   csv_fnames = glob.glob(f'{data_dir}/inference/*.csv')
   csv_fnames.sort()  # TODO: sort by number
   for csv_fname in csv_fnames:
@@ -33,6 +33,8 @@ def register_inference_services(engine: Engine, data_dir: str, port=8000, batch_
     if service_name.endswith('__join'):
       service_name = service_name.split('__')[0]
 
+    if service_name in cost_dict:
+      cost = cost_dict[service_name]
     service = HTTPInferenceService(
       service_name,
       False,
@@ -42,6 +44,7 @@ def register_inference_services(engine: Engine, data_dir: str, port=8000, batch_
       response_keys_to_columns=output_keys_to_columns,
       batch_supported=batch_supported,
       preferred_batch_size=preferred_batch_size,
+      cost=cost
     )
 
     engine.register_inference_service(service)

--- a/tests/inference_service_utils/inference_service_setup.py
+++ b/tests/inference_service_utils/inference_service_setup.py
@@ -35,6 +35,8 @@ def register_inference_services(engine: Engine, data_dir: str, port=8000, batch_
 
     if service_name in cost_dict:
       cost = cost_dict[service_name]
+    else:
+      cost = None
     service = HTTPInferenceService(
       service_name,
       False,

--- a/tests/test_order_optimization.py
+++ b/tests/test_order_optimization.py
@@ -1,0 +1,90 @@
+from aidb.utils.order_optimization_utils import get_currently_supported_filtering_predicates_for_ordering
+from aidb.query.query import Query
+
+from multiprocessing import Process
+import os
+from sqlalchemy.sql import text
+import time
+import unittest
+from unittest import IsolatedAsyncioTestCase
+import numpy as np
+import pandas as pd
+import multiprocessing as mp
+
+from aidb.utils.logger import logger
+from tests.inference_service_utils.inference_service_setup import register_inference_services
+from tests.inference_service_utils.http_inference_service_setup import run_server
+from tests.tasti_test.tasti_test import TastiTests, VectorDatabaseType
+from tests.utils import setup_gt_and_aidb_engine, setup_test_logger
+from aidb.vector_database.faiss_vector_database import FaissVectorDatabase
+from aidb.vector_database.tasti import Tasti
+
+setup_test_logger('limit_engine')
+
+POSTGRESQL_URL = 'postgresql+asyncpg://user:testaidb@localhost:5432'
+SQLITE_URL = 'sqlite+aiosqlite://'
+MYSQL_URL = 'mysql+aiomysql://root:testaidb@localhost:3306'
+
+DATA_SET = 'twitter'
+BUDGET = 5000
+
+class LimitEngineTests(IsolatedAsyncioTestCase):
+
+  async def test_jackson_number_objects(self):
+
+    dirname = os.path.dirname(__file__)
+    data_dir = os.path.join(dirname, f'data/{DATA_SET}')
+    p = Process(target=run_server, args=[str(data_dir), 8050])
+    p.start()
+    time.sleep(1)
+
+    # vector database configuration
+    index_path = './'
+    index_name = DATA_SET
+    embedding = np.load(f'./tests/data/embedding/{DATA_SET}_embeddings.npy')
+    embedding_df = pd.DataFrame({'id': range(embedding.shape[0]), 'values': embedding.tolist()})
+
+    embedding_dim = embedding.shape[1]
+    user_database = FaissVectorDatabase(index_path)
+    user_database.create_index(index_name, embedding_dim, recreate_index=True)
+    user_database.insert_data(index_name, embedding_df)
+    seed = mp.current_process().pid
+    tasti = Tasti(index_name, user_database, BUDGET, seed=seed)
+
+    queries = [
+      (
+        '''SELECT * FROM entity00 join sentiment01 on entity00.tweet_id = sentiment01.tweet_id WHERE type LIKE 'ORG' AND label LIKE 'positive';''',
+        '''SELECT * FROM entity00 join sentiment01 on entity00.tweet_id = sentiment01.tweet_id WHERE type LIKE 'ORG' AND label LIKE 'positive';'''
+      )
+    ]
+    db_url_list = [ SQLITE_URL]
+    for db_url in db_url_list:
+      dialect = db_url.split('+')[0]
+      logger.info(f'Test {dialect} database')
+      for aidb_query, exact_query in queries:
+        logger.info(f'Running query {aidb_query} in limit engine')
+
+        gt_engine, aidb_engine = await setup_gt_and_aidb_engine(db_url, data_dir, tasti, port=8050)
+        cost_dict = {'entity00': 15, 'sentiment01': 2.25}
+        register_inference_services(aidb_engine, data_dir, port=8050, cost_dict=cost_dict)
+        aidb_res = aidb_engine.execute(aidb_query)
+
+        logger.info(f'Running query {exact_query} in ground truth database')
+        try:
+          async with gt_engine.begin() as conn:
+            gt_res = await conn.execute(text(exact_query))
+            gt_res = gt_res.fetchall()
+        finally:
+          await gt_engine.dispose()
+
+        logger.info(f'There are {len(aidb_res)} elements in limit engine results '
+              f'and {len(gt_res)} elements in ground truth results')
+        assert len(set(aidb_res) - set(gt_res)) == 0
+
+      del gt_engine
+      del aidb_engine
+    p.terminate()
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/test_order_optimization.py
+++ b/tests/test_order_optimization.py
@@ -19,7 +19,7 @@ from tests.utils import setup_gt_and_aidb_engine, setup_test_logger
 from aidb.vector_database.faiss_vector_database import FaissVectorDatabase
 from aidb.vector_database.tasti import Tasti
 
-setup_test_logger('limit_engine')
+setup_test_logger('order_optimization')
 
 POSTGRESQL_URL = 'postgresql+asyncpg://user:testaidb@localhost:5432'
 SQLITE_URL = 'sqlite+aiosqlite://'
@@ -74,7 +74,7 @@ class LimitEngineTests(IsolatedAsyncioTestCase):
       dialect = db_url.split('+')[0]
       logger.info(f'Test {dialect} database')
       for aidb_query, exact_query in queries:
-        logger.info(f'Running query {aidb_query} in limit engine')
+        logger.info(f'Running query {aidb_query} in full scan engine to test the optimization of ML ordering')
 
         gt_engine, aidb_engine = await setup_gt_and_aidb_engine(db_url, data_dir, tasti, port=8050)
         cost_dict = {'entity00': 0.0010, 'sentiment01': 0.0010}

--- a/tests/test_order_optimization.py
+++ b/tests/test_order_optimization.py
@@ -53,8 +53,20 @@ class LimitEngineTests(IsolatedAsyncioTestCase):
 
     queries = [
       (
-        '''SELECT * FROM entity00 join sentiment01 on entity00.tweet_id = sentiment01.tweet_id WHERE type LIKE 'ORG' AND label LIKE 'positive';''',
-        '''SELECT * FROM entity00 join sentiment01 on entity00.tweet_id = sentiment01.tweet_id WHERE type LIKE 'ORG' AND label LIKE 'positive';'''
+        '''SELECT * FROM entity00 join sentiment01 on entity00.tweet_id = sentiment01.tweet_id WHERE type LIKE 'ORG' AND label LIKE 'POSITIVE';''',
+        '''SELECT * FROM entity00 join sentiment01 on entity00.tweet_id = sentiment01.tweet_id WHERE type LIKE 'ORG' AND label LIKE 'POSITIVE';'''
+      ),
+      (
+        '''SELECT * FROM entity00 join sentiment01 on entity00.tweet_id = sentiment01.tweet_id WHERE type LIKE 'ORG' AND label LIKE 'NEGATIVE';''',
+        '''SELECT * FROM entity00 join sentiment01 on entity00.tweet_id = sentiment01.tweet_id WHERE type LIKE 'ORG' AND label LIKE 'NEGATIVE';'''
+      ),
+      (
+        '''SELECT * FROM entity00 join sentiment01 on entity00.tweet_id = sentiment01.tweet_id WHERE type IN ('ORG', 'CARDINAL', 'PERSON') AND label LIKE 'POSITIVE';''',
+        '''SELECT * FROM entity00 join sentiment01 on entity00.tweet_id = sentiment01.tweet_id WHERE type IN ('ORG', 'CARDINAL', 'PERSON') AND label LIKE 'POSITIVE';'''
+      ),
+      (
+        '''SELECT * FROM entity00 join sentiment01 on entity00.tweet_id = sentiment01.tweet_id WHERE type IN ('ORG', 'CARDINAL', 'PERSON') AND label LIKE 'NEGATIVE';''',
+        '''SELECT * FROM entity00 join sentiment01 on entity00.tweet_id = sentiment01.tweet_id WHERE type IN ('ORG', 'CARDINAL', 'PERSON') AND label LIKE 'NEGATIVE';'''
       )
     ]
     db_url_list = [ SQLITE_URL]
@@ -65,7 +77,7 @@ class LimitEngineTests(IsolatedAsyncioTestCase):
         logger.info(f'Running query {aidb_query} in limit engine')
 
         gt_engine, aidb_engine = await setup_gt_and_aidb_engine(db_url, data_dir, tasti, port=8050)
-        cost_dict = {'entity00': 15, 'sentiment01': 2.25}
+        cost_dict = {'entity00': 0.0010, 'sentiment01': 0.0010}
         register_inference_services(aidb_engine, data_dir, port=8050, cost_dict=cost_dict)
         aidb_res = aidb_engine.execute(aidb_query)
 
@@ -79,6 +91,7 @@ class LimitEngineTests(IsolatedAsyncioTestCase):
 
         logger.info(f'There are {len(aidb_res)} elements in limit engine results '
               f'and {len(gt_res)} elements in ground truth results')
+        logger.info(f'difference: {set(aidb_res) - set(gt_res)}')
         assert len(set(aidb_res) - set(gt_res)) == 0
 
       del gt_engine

--- a/tests/tests_full_scan_engine_udf.py
+++ b/tests/tests_full_scan_engine_udf.py
@@ -109,7 +109,7 @@ class FullScanEngineUdfTests(IsolatedAsyncioTestCase):
     p = Process(target=run_server, args=[str(data_dir), port])
     p.start()
     time.sleep(1)
-    gt_engine, aidb_engine = await setup_gt_and_aidb_engine(SQLITE_URL, data_dir, port)
+    gt_engine, aidb_engine = await setup_gt_and_aidb_engine(SQLITE_URL, data_dir, port=port)
 
     register_inference_services(aidb_engine, data_dir, port)
 


### PR DESCRIPTION
This PR implements the ordering of ML execution:
1. Only the inference based on blob will be reordered.
2. The order is determined by **engine_cost** * **selectivity**, where selectivity is calculated as the sum of each blob’s proxy score (0 or 1) divided by the total number of blobs.